### PR TITLE
#4 rename template from basic to navy

### DIFF
--- a/src/templates.json
+++ b/src/templates.json
@@ -1,3 +1,3 @@
 {
-  "basic": "https://github.com/lightning-resume/boilerplate-react.git"
+  "navy": "https://github.com/lightning-resume/template-navy-react.git"
 }


### PR DESCRIPTION
**Description**
Basic template has changed its url and now its `https://github.com/resume-site-builder/template-navy-react`
Also, I think basic is not describing the name of the template that's why I have changed to Navy

**Metadata**

- Fixes #[Link to Issue]
